### PR TITLE
Keep hover class when leaving navTrack area

### DIFF
--- a/src/mickey.js
+++ b/src/mickey.js
@@ -325,9 +325,7 @@
          (newAr !== memAr || !newLimit || fallback)) {
         mouse.pos = box.center();
         mouse.el = newEl;
-        if (newAr === memAr || !_.isUndefined(newAr.dataset.navTrack)) {
-          $rmvClass(memEl, options.hoverClass);
-        }
+        $rmvClass(memEl, options.hoverClass, (newAr === memAr || !_.isUndefined(newAr.dataset.navTrack)));
         $addClass(newEl, options.hoverClass, !newLimit);
         dispatchEvent(memEl, 'mouseout');
         dispatchEvent(newEl, 'mouseover');


### PR DESCRIPTION
@jinroh Depuis le passage à la _new-nav_ de la webapp, dans le menu _settings_, lorsqu'on quitte la zone `nav-track`, on perd la "trace". La classe `.hover`  est systématiquement enlevée.

J'ai fait un petit (dirty?) fix ici en conditionnant `$rmvClass()`, et ce serait cool de l'avoir aussi dans la webapp.

:wink:
@ludovicmnji 
@MatthieuGOENAGA
